### PR TITLE
Typo: Rename g1-> g2

### DIFF
--- a/RSA-encryption/Attack-Franklin-Reiter/exploit.sage
+++ b/RSA-encryption/Attack-Franklin-Reiter/exploit.sage
@@ -11,7 +11,7 @@ def gcd(a, b):
 def franklinreiter(C1, C2, e, N, a, b):
     P.<X> = PolynomialRing(Zmod(N))
     g1 = (aX + b)^e - C1
-    g1 = X^e - C2
+    g2 = X^e - C2
     print "Result"
     result = -gcd(g1, g2).coefficients()[0]
     return hex(int(result))[2:].replace("L","").decode("hex")


### PR DESCRIPTION
Fix for typo in script