### PR TITLE
Fix RSA LSBit Oracle attack to not mess up last bytes

### DIFF
--- a/RSA-encryption/Attack-LSBit-Oracle/exploit.py
+++ b/RSA-encryption/Attack-LSBit-Oracle/exploit.py
@@ -31,21 +31,25 @@ print "N: ", N
 print "\n\n"
 
 e = 65537
-upper_limit = N
+upper_limit = 1
 lower_limit = 0
+denominator = 1
 
 flag = ""
-i = 1
-while i <= 1034:
+for i in range(1, N.bit_length()+1):
     chosen_ct = long_to_bytes((bytes_to_long(flag_enc)*pow(2**i, e, N)) % N)
     output = _decrypt(chosen_ct)
+    delta = upper_limit - lower_limit
+    upper_limit *= 2
+    lower_limit *= 2
+    denominator *= 2
     if ord(output[-1]) == 0:
-        upper_limit = (upper_limit + lower_limit)/2
+        upper_limit -= delta
     elif ord(output[-1]) == 1:
-        lower_limit = (lower_limit + upper_limit)/2
+        lower_limit += delta
     else:
         break
         print "Unsuccessfull"
-    i += 1
 
-print "Flag : ", long_to_bytes(lower_limit)
+flag = N * lower_limit / denominator
+print "Flag : ", long_to_bytes(flag)


### PR DESCRIPTION
The previous approach of updating the upper/lower limits to be the
mid-point between them would truncate the result multiple times along
the way, leading to an incorrect last byte at the end. By keeping track
of numerators/denominators separately, we can get an accurate
decryption.

Learned about this approach from:
https://github.com/akalin/cryptopals-python3/blob/master/challenge46.py

Tested with `exploit.py`, where I am now able to recover a full flag, instead of getting incorrect last bytes.
Also tested `lsbitoracle.py` by creating a small script that calls it, where it also recovers the full flag now.